### PR TITLE
fix error TypeError: can't concat str to bytes

### DIFF
--- a/tuyaface/__init__.py
+++ b/tuyaface/__init__.py
@@ -79,7 +79,7 @@ def _generate_payload(
         if command == CMD_TYPE.CONTROL:
             payload_crypt = aescipher.encrypt(device["localkey"], payload_json)
             premd5string = (
-                b"data=" + payload_crypt + b"||lpv=" + b"3.1||" + device["localkey"]
+                b"data=" + payload_crypt + b"||lpv=" + b"3.1||" + bytes(device["localkey"], "latin1")
             )
             m = md5()
             m.update(premd5string)


### PR DESCRIPTION
This line produces the error below running with Python3:

    File "/usr/local/lib/python3.9/site-packages/tuyaface/tuyaclient.py", line 194, in run
      result = command(*args)
    File "/usr/local/lib/python3.9/site-packages/tuyaface/tuyaclient.py", line 257, in _set_state
      state_reply, all_replies = _set_status(self.device, value)
    File "/usr/local/lib/python3.9/site-packages/tuyaface/__init__.py", line 320, in _set_status
      request_cnt = _send_request(device, CMD_TYPE.CONTROL, tmp)
    File "/usr/local/lib/python3.9/site-packages/tuyaface/__init__.py", line 429, in _send_request
      request = _generate_payload(device, command, payload, request_cnt)
    File "/usr/local/lib/python3.9/site-packages/tuyaface/__init__.py", line 82, in _generate_payload
      b"data=" + payload_crypt + b"||lpv=" + b"3.1||" + device["localkey"]
  TypeError: can't concat str to byte

device["localkey"] needs to be converted to bytes

I have tested the fix with a Heater and works fine.

